### PR TITLE
Added a script to make dev tests easier and updated the README file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ nightwatch/screenshots
 nightwatch/reports
 nightwatch/*.log
 /mycredentials
+
+**/npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # End to End tests 
 
-There are two ways to run the tests, if you want to just get started quickly then use docker, if you want to integrate this into your IDE for example for example you might prefer to run the code on your machine.
+There are two ways to run the tests, if you want to just get started quickly then use docker, if you want to integrate this into your IDE for example you might prefer to run the code on your machine.
 
 
 ## Running the code on your machine:
@@ -15,7 +15,10 @@ nvm use 4.2
 npm install
 
 # Run tests against localhost
-node_modules/.bin/nightwatch --env default
+./test.sh
+
+# Once you've setup the keycloak credentials file (see bottom)
+# ./test.sh [docker|dev|int|uat] will also work
 ```
 
 

--- a/nightwatch/test.sh
+++ b/nightwatch/test.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+ENV=$1
+[ -z "$ENV" ] && ENV='default'
+
+if [ "$ENV" != "default" ] ; then
+    CRED="../mycredentials"
+    [ ! -f $CRED ] && echo "Could not find credentials file: $CRED" && exit 1
+    CRED="env `cat $CRED`"
+fi
+
+$CRED ./node_modules/.bin/nightwatch --env $ENV

--- a/nightwatch/test.sh
+++ b/nightwatch/test.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-ENV=$1
-[ -z "$ENV" ] && ENV='default'
+cd $(dirname $0)
 
-if [ "$ENV" != "default" ] ; then
+ARGS="$@"
+[ -z "$ARGS" ] && ARGS='--env default'
+
+if [[ "$ARGS" != *"--env default"* ]] ; then
     CRED="../mycredentials"
     [ ! -f $CRED ] && echo "Could not find credentials file: $CRED" && exit 1
-    CRED="env `cat $CRED`"
+    set -o allexport
+    source $CRED
+    set +o allexport
 fi
 
-$CRED ./node_modules/.bin/nightwatch --env $ENV
+./node_modules/.bin/nightwatch $ARGS

--- a/nightwatch/test.sh
+++ b/nightwatch/test.sh
@@ -7,10 +7,14 @@ ARGS="$@"
 
 if [[ "$ARGS" != *"--env default"* ]] ; then
     CRED="../mycredentials"
-    [ ! -f $CRED ] && echo "Could not find credentials file: $CRED" && exit 1
-    set -o allexport
-    source $CRED
-    set +o allexport
+    if [ -f $CRED ] ; then
+        set -o allexport
+        source $CRED
+        set +o allexport
+    else
+        echo "WARNING: No KeyCloak credentials found, creating blank file: $CRED"
+        printf "KEYCLOAK_USER=\nKEYCLOAK_PASS=" > $CRED
+    fi
 fi
 
 ./node_modules/.bin/nightwatch $ARGS


### PR DESCRIPTION
Added a `test.sh` script to make developer testing a bit easier and added a note in the README file.
Improved the `test.sh` script to: better handle the passing of KeyCloak credentials to the `nightwatch` environment; honor and forward all program arguments; allow the script to be runnable from directories other than its parent.
