### PR TITLE
Check CID IDs in drilldowns are clickable

### DIFF
--- a/nightwatch/features/event.feature
+++ b/nightwatch/features/event.feature
@@ -36,7 +36,7 @@ Feature: Unreconciled Events
       | Expected incoming      | 0    |
       | Expected outgoing      | 0    |
       | Unexpected incoming    | 1    |
-    And the Centre "one" should show the following CIDS under "Male" "Unexpected incoming":
+    And the Centre "one" should show the following CIDS under "Male" "Unexpected incoming", which should be clickable:
       | CID Person ID |
       | 999999        |
 

--- a/nightwatch/features/movement.feature
+++ b/nightwatch/features/movement.feature
@@ -32,7 +32,7 @@ Feature: Movements
       | Expected incoming      | 0    |
       | Expected outgoing      | 1    |
       | Unexpected incoming    | 0    |
-    And the Centre "one" should show the following CIDS under "Male" "Expected outgoing":
+    And the Centre "one" should show the following CIDS under "Male" "Expected outgoing", which should be clickable:
       | CID Person ID |
       | 1433          |
 
@@ -50,6 +50,6 @@ Feature: Movements
       | Expected incoming      | 1    |
       | Expected outgoing      | 0    |
       | Unexpected incoming    | 0    |
-    And the Centre "one" should show the following CIDS under "Male" "Expected incoming":
+    And the Centre "one" should show the following CIDS under "Male" "Expected incoming", which should be clickable:
       | CID Person ID |
       | 12345555      |

--- a/nightwatch/features/step_definitions/steps.js
+++ b/nightwatch/features/step_definitions/steps.js
@@ -18,12 +18,16 @@ module.exports = function () {
     this.page.wallboard().toggleCentreDetails(centreName, gender)
   })
 
-  this.Then(/^the Centre "([^"]*)" should show the following CIDS under "([^"]*)" "([^"]*)":$/, function (centreName, gender, detail, table) {
+  this.Then(/^the Centre "([^"]*)" should show the following CIDS under "([^"]*)" "([^"]*)"(, which should be clickable)?:$/, function (centreName, gender, detail, clickable, table) {
     // @TODO: add something to test order
+    if (typeof table === 'function') {
+      table = clickable
+      clickable = false
+    }
     this.page.wallboard().toggleCentreDetails(centreName, gender)
     this.page.wallboard().toggleCentreDetailsCid(centreName, gender, detail)
     _.map(table.hashes(), (row, index) =>
-      this.page.wallboard().expectCentreDetailCids(centreName, gender, detail, index + 1, row['CID Person ID'])
+      this.page.wallboard().expectCentreDetailCids(centreName, gender, detail, index + 1, row['CID Person ID'], clickable)
     )
     this.page.wallboard().toggleCentreDetailsCid(centreName, gender, detail)
     this.page.wallboard().toggleCentreDetails(centreName, gender)

--- a/nightwatch/page_objects/wallboard.js
+++ b/nightwatch/page_objects/wallboard.js
@@ -27,9 +27,14 @@ module.exports = {
       this.expect.element(`${getCentreGenderScope(centreName, gender)}//td/text()[contains(., "${k}")]/ancestor::tr/td[last()]`).text.to.equal(v).before(2000)
       this.api.useCss()
     },
-    expectCentreDetailCids: function (centreName, gender, k, i, cid) {
+    expectCentreDetailCids: function (centreName, gender, k, i, cid, clickable) {
       this.api.useXpath()
-      this.expect.element(`${getCentreGenderScope(centreName, gender)}//td/text()[contains(., "${k}")]/ancestor::tr//ul/li[${i}]`).text.to.contain(cid).before(2000)
+      const listItem = `${getCentreGenderScope(centreName, gender)}//td/text()[contains(., "${k}")]/ancestor::tr//ul/li[${i}]`
+      this.expect.element(listItem).text.to.contain(cid).before(2000)
+      if (clickable) { // IBM-243 : check the CID is still visible after clicking on it
+        this.api.click(listItem)
+        this.expect.element(listItem).text.to.contain(cid).before(2000)
+      }
       this.api.useCss()
     }
   }],


### PR DESCRIPTION
Added a simple click check to ensure the CID IDs in the drilldown details can be clicked (and thus selected for copying).
