### PR TITLE
Fix syntax error, add test to stop it happening again

### DIFF
--- a/nightwatch/features/step_definitions/backendPosts.js
+++ b/nightwatch/features/step_definitions/backendPosts.js
@@ -136,3 +136,4 @@ module.exports = function () {
       )
     )
   })
+}

--- a/runtests.sh
+++ b/runtests.sh
@@ -32,9 +32,19 @@ docker-compose logs waiter
 
 echo travis_fold:end:DOCKER_COMPOSE_UP
 
+echo travis_fold:start:LINT
+docker-compose run --rm -T test npm run lint $@
+lintcode=$?
+echo travis_fold:end:LINT
+
 docker-compose run --rm -T test nightwatch $@
-exitcode=$?
+nightwatchcode=$?
 
 docker-compose run --rm -T test nightwatch-html-reporter -d reports -t cover -b false
 
-exit $exitcode
+if [ $(($lintcode + $nightwatchcode)) -ne 0 ]; then
+	echo "Lint exit code: $lintcode"
+	echo "Test exit code: $nightwatchcode"
+	echo "Failure."
+	exit 1
+fi


### PR DESCRIPTION
We got the green tick from Travis with issue #79 even though there was a syntax error in the code, because Nightwatch doesn't exit abnormally if it encounters a syntax error.

This pull request fixes that syntax error, and adds the linter to the CI build script.
This will mean that the build will henceforth fail if either the linter or the test script fails.

This will have the side effect of making the merge process more opinionated: minor formatting discrepancies will fail the build.

BSM-037